### PR TITLE
fix focused container & give output name

### DIFF
--- a/lib/sway/container.vala
+++ b/lib/sway/container.vala
@@ -19,6 +19,7 @@ public class Container : Node {
         floating = obj.get_string_member("type") == "floating_con";
         fullscreen_mode = (int)obj.get_int_member("fullscreen_mode");
         percent = (float)obj.get_double_member("percent");
+        focused = obj.get_boolean_member("focused");
 
         base.sync(obj);
     }

--- a/lib/sway/workspace.vala
+++ b/lib/sway/workspace.vala
@@ -4,6 +4,7 @@ public class Workspace : Node {
     public bool focused { get; private set; }
     public bool visible { get; private set; }
     public int num { get; private set; }
+    public string output { get; private set; }
 
     public Workspace() {
         node_type = NodeType.WORKSPACE;
@@ -24,6 +25,7 @@ public class Workspace : Node {
         focused = obj.get_boolean_member("focused");
         visible = obj.get_boolean_member("visible");
         num = (int)obj.get_int_member("num");
+        output = obj.get_string_member("output");
     }
 
     public override void focus() {


### PR DESCRIPTION
really liked all the work you put in to make this work so far!

two tiny things i changed on my own that i figured would be useful to anyone else using this

fixed containers never getting a focused property

and added a way to differentiate between which workspace is on what monitor
